### PR TITLE
Don't require bash inside flist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ BINARY = ovs-plugin
 
 all: ovs $(BINARY)
 	sudo mkdir -p image/var/lib/corex/plugins
+	sudo mkdir -p image/run/openvswitch
+	sudo mkdir -p image/var/run/openvswitch
 	sudo cp $(BINARY) image/var/lib/corex/plugins
 	sudo cp startup.toml image/.startup.toml
 	sudo cp plugin.toml image/.plugin.toml

--- a/startup.toml
+++ b/startup.toml
@@ -1,13 +1,10 @@
 [startup."ovs.init"]
-name = "bash"
+name = "core.system"
 running_delay = -1
 
 [startup."ovs.init".args]
-script = """
-mkdir -p /run/openvswitch/
-mkdir -p /var/run/openvswitch/
-/usr/bin/ovsdb-tool create /etc/openvswitch/conf.db
-"""
+name = "/usr/bin/ovsdb-tool"
+args = ["create", "/etc/openvswitch/conf.db"]
 
 [startup.ovsdb]
 name = "core.system"


### PR DESCRIPTION
Make directories requires during image building
So the image does not require mkdir and bash

Signed-off-by: Jo De Boeck <deboeck.jo@gmail.com>